### PR TITLE
Fixes #9 http 500 after login

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - 38080:38080
     environment:
-      MONGODB_URI: mongodb://ppnext:ppnext@localhost:27017/?authSource=ppnext
+      MONGODB_URI: mongodb://ppnext:ppnext@mongo:27017/?authSource=ppnext
   mongo:
     image: mongo:latest
     environment:


### PR DESCRIPTION
Containers should access each other by their hostnames when they are in the same network.